### PR TITLE
fix: refresh cached pages after deploy

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,5 @@
+---
+---
 /* ===========================================================
  * sw.js
  * ===========================================================
@@ -9,7 +11,8 @@
 // CACHE_NAMESPACE
 // CacheStorage is shared between all sites under same domain.
 // A namespace can prevent potential name conflicts and mis-deletion.
-const CACHE_NAMESPACE = 'main-'
+// Use build timestamp to invalidate old caches after each deployment
+const CACHE_NAMESPACE = 'main-{{ site.time | date: "%Y%m%d%H%M%S" }}-'
 
 const CACHE = CACHE_NAMESPACE + 'precache-then-runtime';
 const PRECACHE_LIST = [


### PR DESCRIPTION
## Summary
- make service worker cache name include build timestamp to invalidate outdated caches

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6898965c90a8832c85aa04513560b112